### PR TITLE
feat: 로그인/회원가입 - Assignment 2 - 회원가입 후 로그인 페이지로 이동

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "prune_local": "echo git remote prune origin && git branch -vv | grep ': gone]'| awk '{print $1}' | xargs git branch -D"
   },
   "eslintConfig": {
     "extends": [

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,4 +1,6 @@
 import { ChangeEvent, useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import { postSignup } from './api'
 
 interface ErrorState {
   error: boolean
@@ -22,7 +24,23 @@ const SignUpPage = () => {
     error: false,
     errorMessage: '',
   })
+  const [userSignedUp, setUserSignedUp] = useState(false)
+
   const isSubmittable = !email.error && !password.error
+
+  const postSignupRequest = async () => {
+    const res = await postSignup({
+      email: email.email,
+      password: password.password,
+    })
+    if (!res.error) {
+      alert('회원가입 성공')
+      setUserSignedUp(true)
+    } else {
+      alert(`회원가입에 실패했습니다 다시 시도해주세요 : ${res.body}`)
+    }
+    return res
+  }
 
   const handleEmailChange = (e: ChangeEvent<HTMLInputElement>) => {
     const regExp = new RegExp('[@]')
@@ -59,8 +77,10 @@ const SignUpPage = () => {
           errorMessage: 'Password should have at least 8 characters',
         }))
   }
+
   return (
     <div>
+      {userSignedUp && <Navigate to="/signin" />}
       Sign Up Page
       <form>
         <label htmlFor="email" title="email 입력란">
@@ -94,8 +114,9 @@ const SignUpPage = () => {
           type="button"
           data-testid="signup-button"
           disabled={!isSubmittable}
+          onClick={postSignupRequest}
         >
-          submit
+          Sign Up
         </button>
       </form>
     </div>

--- a/src/pages/api.ts
+++ b/src/pages/api.ts
@@ -1,0 +1,75 @@
+const BASE_API_URL = 'https://www.pre-onboarding-selection-task.shop'
+
+type SignupBody = { email: string; password: string }
+type SigninBody = { email: string; password: string }
+
+type AuthBodyType = SignupBody | SigninBody
+
+type PostDataType = AuthBodyType
+type PostDataReturnType = { status: number; body: string; error: boolean }
+
+const API_URL = {
+  signup: '/auth/signup',
+  signin: '/auth/signin',
+}
+
+const postSignupData = async (url: string, data: PostDataType) => {
+  const parsedUrl = BASE_API_URL + url
+  const response = await fetch(parsedUrl, {
+    method: 'POST',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  })
+  return response
+}
+
+const postData = async (url: string, data: PostDataType) => {
+  const parsedUrl = BASE_API_URL + url
+  const response = await fetch(parsedUrl, {
+    method: 'POST',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  })
+
+  return response.json()
+}
+
+const postSignup = async (data: AuthBodyType): Promise<PostDataReturnType> => {
+  try {
+    const response = await postSignupData(API_URL.signup, data)
+    if (response.ok) {
+      return { status: 201, body: 'Created', error: false }
+    } else {
+      const parsedBody = await response.json()
+      return {
+        status: parsedBody.statusCode,
+        body: parsedBody.message,
+        error: true,
+      }
+    }
+  } catch (e) {
+    return { status: 401, body: `${e}`, error: true }
+  }
+}
+
+const postSignin = async (data: AuthBodyType): Promise<PostDataReturnType> => {
+  try {
+    const parsedRes = await postData(API_URL.signin, data)
+    if (parsedRes.access_token) {
+      return { status: 200, error: false, body: parsedRes.access_token }
+    } else {
+      const { statusCode, message } = parsedRes
+      return { status: statusCode, error: true, body: message }
+    }
+  } catch (e) {
+    return { status: 400, body: `${e}`, error: true }
+  }
+}
+
+export { API_URL, postSignup, postSignin }


### PR DESCRIPTION
# Description
## Summary
closes #4 
회원가입 후 로그인 페이지로 이동

## Changes
- 리모트 저장소에서 삭제된 브랜치들을 로컬에서도 삭제하는 npm 스크립트를 추가했습니다
- 회원가입/로그인 관련 함수들을 `api.ts`에 추가했습니다
- 회원가입이 성공적으로 이루어진 경우, 로그인페이지로 이동시킵니다