### PR TITLE
feat: 로그인/회원가입 - Assignment 4 - 로그인 여부에 따른 리다이렉트 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,16 @@
+import { Outlet } from 'react-router-dom'
+import NavBar from './components/NavBar'
+
 function App() {
-  return <div className="App">Home</div>
+  return (
+    <div className="App">
+      <NavBar />
+      {"Welcome to Seungrok's Todo!"}
+      <main>
+        <Outlet />
+      </main>
+    </div>
+  )
 }
 
 export default App

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -1,5 +1,4 @@
 import {
-  Dispatch,
   PropsWithChildren,
   createContext,
   useContext,
@@ -8,29 +7,45 @@ import {
 } from 'react'
 
 type AuthState = {
-  userState: { auth: boolean; token: string }
-  setUserState: Dispatch<
-    React.SetStateAction<{
-      auth: boolean
-      token: string
-    }>
-  >
+  userState: { auth: boolean }
+  signinUser: (token: string) => void
+  signoutUser: () => void
+  checkUserAuth: () => boolean
 }
 
-export const AuthContext = createContext<AuthState | null>(null)
+const AuthContext = createContext<AuthState | null>(null)
 
 export const AuthProvider = ({ children }: PropsWithChildren) => {
-  const [userState, setUserState] = useState({ auth: false, token: '' })
+  const [userState, setUserState] = useState({ auth: false })
+
+  const getAccessToken = () => {
+    const accessToken = localStorage.getItem('access_token')
+    return accessToken ? accessToken : null
+  }
+
+  const signinUser = (token: string) => {
+    localStorage.setItem('access_token', token)
+    setUserState(() => ({ auth: true }))
+  }
+
+  const signoutUser = () => {
+    localStorage.removeItem('access_token')
+    setUserState(() => ({ auth: false }))
+  }
+
+  const checkUserAuth = () => {
+    const accessToken = getAccessToken()
+    return accessToken !== null && accessToken.length > 0 && userState.auth
+  }
 
   useEffect(() => {
-    const accessToken = localStorage.getItem('access_token')
-    accessToken
-      ? setUserState((prev) => ({ ...prev, auth: true, token: accessToken }))
-      : ''
+    getAccessToken() ? setUserState(() => ({ auth: true })) : ''
   }, [])
 
   return (
-    <AuthContext.Provider value={{ userState, setUserState }}>
+    <AuthContext.Provider
+      value={{ userState, signinUser, signoutUser, checkUserAuth }}
+    >
       {children}
     </AuthContext.Provider>
   )

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,42 @@
+import { Link } from 'react-router-dom'
+import { useAuthState } from '../AuthProvider'
+import styled from '@emotion/styled'
+
+const NavBar = () => {
+  const { checkUserAuth, signoutUser } = useAuthState()
+
+  return (
+    <Header>
+      <nav>
+        {!checkUserAuth() && (
+          <div>
+            <Link to="/signin">로그인</Link>
+            <Link to="/signup">회원가입</Link>
+          </div>
+        )}
+        {checkUserAuth() && (
+          <button
+            type="button"
+            onClick={() => {
+              const token = localStorage.getItem('access_token')
+              token ? localStorage.setItem('access_token', '') : ''
+              signoutUser()
+              alert('Logged Out')
+            }}
+          >
+            Log out
+          </button>
+        )}
+      </nav>
+    </Header>
+  )
+}
+
+export default NavBar
+
+const Header = styled.header`
+  width: 100vw;
+  height: 5rem;
+  padding: 0.25rem 1rem;
+  background-color: 27282D;
+`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,19 +3,26 @@ import ReactDOM from 'react-dom/client'
 import reportWebVitals from './reportWebVitals'
 import { RouterProvider, createBrowserRouter } from 'react-router-dom'
 import App from './App'
+import HomePage from './pages/HomePage'
 import SignUpPage from './pages/SignUpPage'
 import SignInPage from './pages/SignInPage'
 import TodoPage from './pages/TodoPage'
 import { AuthProvider } from './AuthProvider'
 
 const router = createBrowserRouter([
-  { path: '/', element: <App /> },
   {
-    path: '/signup',
-    element: <SignUpPage />,
+    path: '/',
+    element: <App />,
+    children: [
+      { index: true, element: <HomePage /> },
+      {
+        path: 'signup',
+        element: <SignUpPage />,
+      },
+      { path: 'signin', element: <SignInPage /> },
+      { path: 'todo', element: <TodoPage /> },
+    ],
   },
-  { path: '/signin', element: <SignInPage /> },
-  { path: '/todo', element: <TodoPage /> },
 ])
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,16 @@
+import { Link } from 'react-router-dom'
+
+const HomePage = () => {
+  return (
+    <div>
+      HomePage
+      <div>
+        <button type="button">
+          <Link to="/todo">TodoList 구경하러 가기</Link>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default HomePage

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -15,7 +15,7 @@ interface PasswordState extends ErrorState {
 }
 
 const SignInPage = () => {
-  const { userState, setUserState } = useAuthState()
+  const { signinUser, checkUserAuth } = useAuthState()
   const [email, setEmail] = useState<EmailState>({
     email: '',
     error: false,
@@ -35,8 +35,7 @@ const SignInPage = () => {
     })
     if (!res.error) {
       alert('로그인 성공')
-      localStorage.setItem('access_token', res.body)
-      setUserState((prev) => ({ ...prev, auth: true, token: res.body }))
+      signinUser(res.body)
     } else {
       alert(`로그인 실패: ${res.body}`)
     }
@@ -80,7 +79,7 @@ const SignInPage = () => {
   }
   return (
     <>
-      {userState.auth ? (
+      {checkUserAuth() ? (
         <Navigate to="/todo" />
       ) : (
         <div>

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -80,50 +80,53 @@ const SignInPage = () => {
   }
   return (
     <>
-      {userState.auth && <Navigate to="/todo" />}
-      <div>
-        Sign In Page
-        <form>
-          <label htmlFor="email" title="email 입력란">
-            <input
-              id="email"
-              name="user_email"
-              type="email"
-              data-testid="email-input"
-              placeholder="이메일을 입력해주세요"
-              value={email.email}
-              onChange={handleEmailChange}
-              required
-              pattern="@{1}"
-            />
-            <div className="validation-note">{email.errorMessage}</div>
-          </label>
-          <label htmlFor="password" title="password 입력란">
-            <input
-              id="password"
-              name="user_password"
-              type="password"
-              data-testid="password-input"
-              placeholder="비밀번호를 입력해주세요"
-              value={password.password}
-              onChange={handlePasswordChange}
-              required
-            />
-            <div className="validation-note">{password.errorMessage}</div>
-          </label>
-          <button
-            type="button"
-            data-testid="signin-button"
-            disabled={!isSubmittable}
-            onClick={postSigninRequest}
-          >
-            Sign In
-          </button>
-          <div>
-            <Link to={'/signup'}>go to Sign Up</Link>
-          </div>
-        </form>
-      </div>
+      {userState.auth ? (
+        <Navigate to="/todo" />
+      ) : (
+        <div>
+          Sign In Page
+          <form>
+            <label htmlFor="email" title="email 입력란">
+              <input
+                id="email"
+                name="user_email"
+                type="email"
+                data-testid="email-input"
+                placeholder="이메일을 입력해주세요"
+                value={email.email}
+                onChange={handleEmailChange}
+                required
+                pattern="@{1}"
+              />
+              <div className="validation-note">{email.errorMessage}</div>
+            </label>
+            <label htmlFor="password" title="password 입력란">
+              <input
+                id="password"
+                name="user_password"
+                type="password"
+                data-testid="password-input"
+                placeholder="비밀번호를 입력해주세요"
+                value={password.password}
+                onChange={handlePasswordChange}
+                required
+              />
+              <div className="validation-note">{password.errorMessage}</div>
+            </label>
+            <button
+              type="button"
+              data-testid="signin-button"
+              disabled={!isSubmittable}
+              onClick={postSigninRequest}
+            >
+              Sign In
+            </button>
+            <div>
+              <Link to={'/signup'}>go to Sign Up</Link>
+            </div>
+          </form>
+        </div>
+      )}
     </>
   )
 }

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -25,7 +25,7 @@ const SignUpPage = () => {
     error: false,
     errorMessage: '',
   })
-  const { userState } = useAuthState()
+  const { checkUserAuth } = useAuthState()
   const navigate = useNavigate()
 
   const isSubmittable = !email.error && !password.error
@@ -82,7 +82,7 @@ const SignUpPage = () => {
 
   return (
     <>
-      {userState.auth ? (
+      {checkUserAuth() ? (
         <Navigate to="/todo" />
       ) : (
         <div>

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, useState } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router-dom'
 import { postSignup } from './api'
+import { useAuthState } from '../AuthProvider'
 
 interface ErrorState {
   error: boolean
@@ -24,7 +25,8 @@ const SignUpPage = () => {
     error: false,
     errorMessage: '',
   })
-  const [userSignedUp, setUserSignedUp] = useState(false)
+  const { userState } = useAuthState()
+  const navigate = useNavigate()
 
   const isSubmittable = !email.error && !password.error
 
@@ -35,7 +37,7 @@ const SignUpPage = () => {
     })
     if (!res.error) {
       alert('회원가입 성공')
-      setUserSignedUp(true)
+      navigate('/todo', { state: '' })
     } else {
       alert(`회원가입에 실패했습니다 다시 시도해주세요 : ${res.body}`)
     }
@@ -79,47 +81,52 @@ const SignUpPage = () => {
   }
 
   return (
-    <div>
-      {userSignedUp && <Navigate to="/signin" />}
-      Sign Up Page
-      <form>
-        <label htmlFor="email" title="email 입력란">
-          <input
-            id="email"
-            name="user_email"
-            type="email"
-            data-testid="email-input"
-            placeholder="이메일을 입력해주세요"
-            value={email.email}
-            onChange={handleEmailChange}
-            required
-            pattern="@{1}"
-          />
-          <div className="validation-note">{email.errorMessage}</div>
-        </label>
-        <label htmlFor="password" title="password 입력란">
-          <input
-            id="password"
-            name="user_password"
-            type="password"
-            data-testid="password-input"
-            placeholder="비밀번호를 입력해주세요"
-            value={password.password}
-            onChange={handlePasswordChange}
-            required
-          />
-          <div className="validation-note">{password.errorMessage}</div>
-        </label>
-        <button
-          type="button"
-          data-testid="signup-button"
-          disabled={!isSubmittable}
-          onClick={postSignupRequest}
-        >
-          Sign Up
-        </button>
-      </form>
-    </div>
+    <>
+      {userState.auth ? (
+        <Navigate to="/todo" />
+      ) : (
+        <div>
+          Sign Up Page
+          <form>
+            <label htmlFor="email" title="email 입력란">
+              <input
+                id="email"
+                name="user_email"
+                type="email"
+                data-testid="email-input"
+                placeholder="이메일을 입력해주세요"
+                value={email.email}
+                onChange={handleEmailChange}
+                required
+                pattern="@{1}"
+              />
+              <div className="validation-note">{email.errorMessage}</div>
+            </label>
+            <label htmlFor="password" title="password 입력란">
+              <input
+                id="password"
+                name="user_password"
+                type="password"
+                data-testid="password-input"
+                placeholder="비밀번호를 입력해주세요"
+                value={password.password}
+                onChange={handlePasswordChange}
+                required
+              />
+              <div className="validation-note">{password.errorMessage}</div>
+            </label>
+            <button
+              type="button"
+              data-testid="signup-button"
+              disabled={!isSubmittable}
+              onClick={postSignupRequest}
+            >
+              Sign Up
+            </button>
+          </form>
+        </div>
+      )}
+    </>
   )
 }
 

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,5 +1,11 @@
+import { Navigate } from 'react-router-dom'
+import { useAuthState } from '../AuthProvider'
+
 const TodoPage = () => {
-  return <div>TodoPage</div>
+  const { userState } = useAuthState()
+  return (
+    <>{!userState.auth ? <Navigate to="/signin" /> : <div>TodoPage</div>}</>
+  )
 }
 
 export default TodoPage


### PR DESCRIPTION
# Description
## Summary
closes #8
로그인 여부에 따른 리다이렉트 처리

## Changes
- 로컬 스토리지에 토큰이 있는 상태로 /signin 또는 /signup 페이지에 접속한다면 /todo 경로로 리다이렉트 시켜줍니다
- 로컬 스토리지에 토큰이 없는 상태로 /todo페이지에 접속한다면 /signin 경로로 리다이렉트 시켜줍니다
- AuthProvider의 state를 사용하는 컴포넌트에서 직접적으로 userState에 수정을 가하지 않고, 함수호출을 통해 간접적으로 수정을 가하도록 리팩토링했습니다
- 모든 페이지에서 `NavBar`컴포넌트를 사용자에게 노출시키고 싶었습니다. Nested Routing 방식이 의도를 구현하기에 유리할 것 같아 라우팅 전략을 수정했습니다
- 회원가입 시, `<Navigate / >` 컴포넌트 사용 대신, `useNavigate`훅을 사용토록 수정했습니다