### PR TITLE
feat: TODO LIST - Assignment 5 - 리스트에 목록 보여주기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,42 @@
 import { Outlet } from 'react-router-dom'
 import NavBar from './components/NavBar'
+import PageLayout from './pages/PageLayout'
+import styled from '@emotion/styled'
 
 function App() {
   return (
-    <div className="App">
+    <Wrapper className="App">
       <NavBar />
-      {"Welcome to Seungrok's Todo!"}
-      <main>
+      <PageLayout>
         <Outlet />
-      </main>
-    </div>
+      </PageLayout>
+      <Footer>
+        <Span>2023 Wanted Pre-onboarding Mission</Span>
+        <Span>by Yoon Seungrok</Span>
+      </Footer>
+    </Wrapper>
   )
 }
 
 export default App
+
+const Wrapper = styled.div`
+  height: 100%;
+`
+
+const Footer = styled.footer`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 5rem;
+  margin-top: 50px;
+  padding: 10px auto;
+`
+
+const Span = styled.span`
+  font-size: 1rem;
+  text-align: center;
+  vertical-align: middle;
+  line-height: 1.5;
+`

--- a/src/GlobalStyles.tsx
+++ b/src/GlobalStyles.tsx
@@ -1,0 +1,20 @@
+import { Global, css } from '@emotion/react'
+
+const GlobalStyles = () => (
+  <Global
+    styles={css`
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      #root,
+      body {
+        width: 100%;
+        height: 100vh;
+      }
+    `}
+  />
+)
+
+export default GlobalStyles

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -35,8 +35,10 @@ const NavBar = () => {
 export default NavBar
 
 const Header = styled.header`
-  width: 100vw;
+  position: fixed;
+  top: 0;
+  width: 100%;
   height: 5rem;
   padding: 0.25rem 1rem;
-  background-color: 27282D;
+  background-color: #27282d;
 `

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled'
+import { useState } from 'react'
+
+interface TodoProps {
+  text: string
+  completed: boolean
+}
+
+const Todo = ({ text, completed }: TodoProps) => {
+  const [isCompleted, setIsCompleted] = useState(completed)
+  return (
+    <Li>
+      <label>
+        <input
+          type="checkbox"
+          checked={isCompleted}
+          onClick={() => {
+            setIsCompleted((prev) => !prev)
+          }}
+        />
+        <span>{text}</span>
+      </label>
+    </Li>
+  )
+}
+
+export default Todo
+
+const Li = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: nowrap;
+  flex: 1;
+  height: 2rem;
+  padding: 0.25rem 1rem;
+  border: 1px solid black;
+  border-radius: 5px;
+`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import SignUpPage from './pages/SignUpPage'
 import SignInPage from './pages/SignInPage'
 import TodoPage from './pages/TodoPage'
 import { AuthProvider } from './AuthProvider'
+import GlobalStyles from './GlobalStyles'
 
 const router = createBrowserRouter([
   {
@@ -29,6 +30,7 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
     <AuthProvider>
+      <GlobalStyles />
       <RouterProvider router={router} />
     </AuthProvider>
   </React.StrictMode>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,14 +2,14 @@ import { Link } from 'react-router-dom'
 
 const HomePage = () => {
   return (
-    <div>
-      HomePage
+    <section>
+      {"Welcome to Seungrok's Todo!"}
       <div>
         <button type="button">
           <Link to="/todo">TodoList 구경하러 가기</Link>
         </button>
       </div>
-    </div>
+    </section>
   )
 }
 

--- a/src/pages/PageLayout.tsx
+++ b/src/pages/PageLayout.tsx
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled'
+import { PropsWithChildren } from 'react'
+
+const PageLayout = ({ children }: PropsWithChildren) => {
+  return <Main>{children}</Main>
+}
+
+export default PageLayout
+
+const Main = styled.main`
+  min-height: calc(100% - 5rem - 50px);
+  padding-top: 5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+`

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -82,7 +82,7 @@ const SignInPage = () => {
       {checkUserAuth() ? (
         <Navigate to="/todo" />
       ) : (
-        <div>
+        <section>
           Sign In Page
           <form>
             <label htmlFor="email" title="email 입력란">
@@ -124,7 +124,7 @@ const SignInPage = () => {
               <Link to={'/signup'}>go to Sign Up</Link>
             </div>
           </form>
-        </div>
+        </section>
       )}
     </>
   )

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -85,7 +85,7 @@ const SignUpPage = () => {
       {checkUserAuth() ? (
         <Navigate to="/todo" />
       ) : (
-        <div>
+        <section>
           Sign Up Page
           <form>
             <label htmlFor="email" title="email 입력란">
@@ -124,7 +124,7 @@ const SignUpPage = () => {
               Sign Up
             </button>
           </form>
-        </div>
+        </section>
       )}
     </>
   )

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -2,14 +2,28 @@ import { Navigate } from 'react-router-dom'
 import { useAuthState } from '../AuthProvider'
 import styled from '@emotion/styled'
 import Todo from '../components/Todo'
+import { useEffect, useState } from 'react'
+import { TodoType, getTodo } from './api'
 
 const TodoPage = () => {
   const { userState } = useAuthState()
-  const dummyTodos = new Array(30).fill(0).map((v, i) => ({
-    id: i + 1,
-    todo: `Test todo ${i + 1}`,
-    isCompleted: v % 2 ? true : false,
-  }))
+  const [todos, setTodos] = useState<TodoType[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isError, setIsError] = useState('')
+
+  const getTodoRequest = async () => {
+    const res = await getTodo()
+    if (res.statusCode === 200) {
+      setTodos(() => res.body as TodoType[])
+    } else {
+      setIsError(res.body as string)
+    }
+    setIsLoading(false)
+  }
+
+  useEffect(() => {
+    getTodoRequest()
+  }, [])
 
   return (
     <>
@@ -19,9 +33,13 @@ const TodoPage = () => {
         <Section>
           <Title>TodoPage</Title>
           <TodoList>
-            {dummyTodos.map(({ id, todo, isCompleted }) => (
-              <Todo key={id} text={todo} completed={isCompleted} />
-            ))}
+            {isLoading && <div>Loading</div>}
+            {isError && <div>{isError}</div>}
+            {!isLoading &&
+              !isError &&
+              todos.map(({ id, todo, isCompleted }) => (
+                <Todo key={id} text={todo} completed={isCompleted} />
+              ))}
           </TodoList>
         </Section>
       )}

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,11 +1,56 @@
 import { Navigate } from 'react-router-dom'
 import { useAuthState } from '../AuthProvider'
+import styled from '@emotion/styled'
+import Todo from '../components/Todo'
 
 const TodoPage = () => {
   const { userState } = useAuthState()
+  const dummyTodos = new Array(30).fill(0).map((v, i) => ({
+    id: i + 1,
+    todo: `Test todo ${i + 1}`,
+    isCompleted: v % 2 ? true : false,
+  }))
+
   return (
-    <>{!userState.auth ? <Navigate to="/signin" /> : <div>TodoPage</div>}</>
+    <>
+      {!userState.auth ? (
+        <Navigate to="/signin" />
+      ) : (
+        <Section>
+          <Title>TodoPage</Title>
+          <TodoList>
+            {dummyTodos.map(({ id, todo, isCompleted }) => (
+              <Todo key={id} text={todo} completed={isCompleted} />
+            ))}
+          </TodoList>
+        </Section>
+      )}
+    </>
   )
 }
 
 export default TodoPage
+
+const Title = styled.h1`
+  margin-top: 10px;
+  margin-bottom: 20px;
+`
+
+const Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+`
+
+const TodoList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 90%;
+  height: 90%;
+  list-style: none;
+  overflow-y: auto;
+`

--- a/src/pages/api.ts
+++ b/src/pages/api.ts
@@ -11,6 +11,7 @@ type PostDataReturnType = { status: number; body: string; error: boolean }
 const API_URL = {
   signup: '/auth/signup',
   signin: '/auth/signin',
+  getTodo: '/todos',
 }
 
 const postSignupData = async (url: string, data: PostDataType) => {
@@ -72,4 +73,41 @@ const postSignin = async (data: AuthBodyType): Promise<PostDataReturnType> => {
   }
 }
 
-export { API_URL, postSignup, postSignin }
+export type GetTodoReturnType = {
+  statusCode: number
+  body: TodoType[] | string
+  error: boolean
+}
+export type TodoType = {
+  id: number
+  todo: string
+  isCompleted: boolean
+  userId: number
+}
+
+const getTodo = async (): Promise<GetTodoReturnType> => {
+  try {
+    const parsedUrl = BASE_API_URL + API_URL.getTodo
+    const accessToken = localStorage.getItem('access_token')
+    const response = await fetch(parsedUrl, {
+      method: 'GET',
+      mode: 'cors',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+    if (!response.ok) {
+      throw new Error('Error occurred while fetching data!')
+    }
+    const body = await response.json()
+    return { statusCode: 200, body, error: false }
+  } catch (e) {
+    let message = 'Unknown Error'
+    if (e instanceof Error) message = e.message
+    console.error(e)
+    return { statusCode: 400, body: message, error: true }
+  }
+}
+
+export { API_URL, postSignup, postSignin, getTodo }


### PR DESCRIPTION
#Description

closes #11 

## Summary
![assignment5](https://github.com/SeungrokYoon/wanted-pre-onboarding-frontend/assets/44149596/9d58bce6-d58c-41f2-adcf-37ace7d77103)

## Changes
- `/todo`경로에서 TODO 목록을 확인할 수 있습니다
  - 각 TODO는 `<Todo/>`컴포넌트로 분리하였습니다 
  - `getTodos` API를 통해 서버로부터 데이터를 받아옵니다
-  TODO의 내용과 완료 여부가 표시됩니다
- `Emotion` 글로벌 스타일 적용을 통해 불필요한 패딩과 마진을 제거했습니다
- 스타일드 컴포넌트를 통해 TODO 페이지를 일부 스타일링했습니다
- footer 를 추가했습니다
