### PR TITLE
feat: TODO LIST - Assignment 6 - 새로운 투두 추가하기

### DIFF
--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,15 +1,16 @@
 import { Navigate } from 'react-router-dom'
 import { useAuthState } from '../AuthProvider'
 import styled from '@emotion/styled'
-import Todo from '../components/Todo'
 import { useEffect, useState } from 'react'
-import { TodoType, getTodo } from './api'
+import { TodoType, createTodo, getTodo } from './api'
+import Todo from '../components/Todo'
 
 const TodoPage = () => {
   const { userState } = useAuthState()
   const [todos, setTodos] = useState<TodoType[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [isError, setIsError] = useState('')
+  const [newTodo, setNewTodo] = useState('')
 
   const getTodoRequest = async () => {
     const res = await getTodo()
@@ -21,29 +22,47 @@ const TodoPage = () => {
     setIsLoading(false)
   }
 
+  const createTodoRequest = async (todo: string) => {
+    const res = await createTodo(todo)
+    if (res.statusCode === 200) {
+      setTodos((prev) => [...prev].concat(res.body as TodoType[]))
+    } else {
+      setIsError(res.body as string)
+    }
+    setIsLoading(false)
+  }
+
   useEffect(() => {
     getTodoRequest()
   }, [])
 
+  if (isLoading) return <div>Loading</div>
+  if (isError) return <div>{isError}</div>
+  if (!userState.auth) return <Navigate to="/signin" />
   return (
-    <>
-      {!userState.auth ? (
-        <Navigate to="/signin" />
-      ) : (
-        <Section>
-          <Title>TodoPage</Title>
-          <TodoList>
-            {isLoading && <div>Loading</div>}
-            {isError && <div>{isError}</div>}
-            {!isLoading &&
-              !isError &&
-              todos.map(({ id, todo, isCompleted }) => (
-                <Todo key={id} text={todo} completed={isCompleted} />
-              ))}
-          </TodoList>
-        </Section>
-      )}
-    </>
+    <Section>
+      <Title>TodoPage</Title>
+      <div>
+        <input
+          data-testid="new-todo-input"
+          placeholder="새로운 할 일"
+          value={newTodo}
+          onChange={(e) => setNewTodo(() => e.target.value)}
+        />
+        <button
+          data-testid="new-todo-add-button"
+          onClick={() => createTodoRequest(newTodo)}
+        >
+          추가
+        </button>
+        <button type="button"></button>
+        <TodoListUl>
+          {todos.map(({ id, todo, isCompleted, userId }) => (
+            <Todo key={`${userId}-${id}`} text={todo} completed={isCompleted} />
+          ))}
+        </TodoListUl>
+      </div>
+    </Section>
   )
 }
 
@@ -62,8 +81,7 @@ const Section = styled.section`
   width: 100%;
   height: 100%;
 `
-
-const TodoList = styled.ul`
+const TodoListUl = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 10px;

--- a/src/pages/api.ts
+++ b/src/pages/api.ts
@@ -12,6 +12,7 @@ const API_URL = {
   signup: '/auth/signup',
   signin: '/auth/signin',
   getTodo: '/todos',
+  createTodo: '/todos',
 }
 
 const postSignupData = async (url: string, data: PostDataType) => {
@@ -110,4 +111,32 @@ const getTodo = async (): Promise<GetTodoReturnType> => {
   }
 }
 
-export { API_URL, postSignup, postSignin, getTodo }
+type PostTodoReturnType = GetTodoReturnType
+
+const createTodo = async (todo: string): Promise<PostTodoReturnType> => {
+  try {
+    const parsedUrl = BASE_API_URL + API_URL.createTodo
+    const accessToken = localStorage.getItem('access_token')
+    const response = await fetch(parsedUrl, {
+      method: 'POST',
+      mode: 'cors',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ todo }),
+    })
+    if (!response.ok) {
+      throw new Error('Error occurred while posting data!')
+    }
+    const body = await response.json()
+    return { statusCode: 200, body: [body], error: false }
+  } catch (e) {
+    let message = 'Unknown Error'
+    if (e instanceof Error) message = e.message
+    console.error(e)
+    return { statusCode: 400, body: message, error: true }
+  }
+}
+
+export { API_URL, postSignup, postSignin, getTodo, createTodo }


### PR DESCRIPTION
#Description

closes #13 

## Summary

![assignment6](https://github.com/SeungrokYoon/wanted-pre-onboarding-frontend/assets/44149596/467a4d40-be5b-4f00-815f-d825cce8f14a)



## Changes
- 'createTodos' API를 통해 새로운 투두를 추가할 수 있습니다
- 새로고침을 하더라도 새로운 투두가 추가된 상태가 유지됩니다
- 로딩상태와 에러 상태를 추가하였습니다

## Further todos...
- 현재 TodoPage 에서 관리하고 있는 상태가 많습니다. Todo 리스트와 관련된 상태를 페이지와 분리하면 좋을 것 같습니다.
- 어느 정도 기능이 완성이 되어갑니다. 보기에 좋은 떡이 먹기에도 좋으니, 미관을 위해 스타일을 추가하려 하면 좋을 듯 싶습니다.