### PR TITLE
refactor: #20 TodoPage 컴포넌트 구조 리팩토링

### DIFF
--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,18 +1,128 @@
 import styled from '@emotion/styled'
-import { PropsWithChildren } from 'react'
+import { Dispatch, PropsWithChildren, createContext, useContext } from 'react'
 import { TodoType } from '../pages/api'
+import useTodoState from '../hooks/useTodoState'
+import Todo from './Todo'
 
-interface TodoListProps extends PropsWithChildren {
-  data: TodoType[]
+type TodoListProps = PropsWithChildren
+
+interface TodoContextType {
+  todos: TodoType[]
+  isLoading: boolean
+  isError: string
+  newTodo: string
+  setNewTodo: Dispatch<React.SetStateAction<string>>
+  focusedTodoId: number | null
+  setFocusedTodoId: Dispatch<React.SetStateAction<number | null>>
+  apiRequests: {
+    getTodoRequest: () => void
+    createTodoRequest: (todo: string) => void
+    updateTodoRequest: (
+      todoId: number,
+      todo: string,
+      isCompleted: boolean
+    ) => void
+    deleteTodoRequest: (todoId: number) => void
+  }
 }
 
-const TodoList = ({ children, data }: TodoListProps) => {
-  return <TodoListWrapper>{children}</TodoListWrapper>
+const TodoContext = createContext<TodoContextType | null>(null)
+
+export const useTodoContext = () => {
+  const context = useContext(TodoContext)
+  if (context === null) {
+    throw new Error('Context value is null type')
+  }
+  return context
+}
+
+const TodoList = ({ children }: TodoListProps) => {
+  const {
+    todos,
+    isLoading,
+    isError,
+    newTodo,
+    setNewTodo,
+    focusedTodoId,
+    setFocusedTodoId,
+    apiRequests,
+  } = useTodoState()
+
+  if (isLoading) return <div>Loading</div>
+  if (isError) return <div>{isError}</div>
+  return (
+    <TodoContext.Provider
+      value={{
+        todos,
+        isLoading,
+        isError,
+        newTodo,
+        setNewTodo,
+        focusedTodoId,
+        setFocusedTodoId,
+        apiRequests,
+      }}
+    >
+      <TodoListWrapper>{children}</TodoListWrapper>
+    </TodoContext.Provider>
+  )
 }
 
 export default TodoList
 
-const TodoListWrapper = styled.ul`
+const TodoListWrapper = styled.div`
+  width: 80%;
+`
+
+const TodoHeader = () => {
+  const { newTodo, setNewTodo, apiRequests } = useTodoContext()
+  return (
+    <>
+      <input
+        data-testid="new-todo-input"
+        placeholder="새로운 할 일"
+        value={newTodo}
+        onChange={(e) => setNewTodo(() => e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            apiRequests.createTodoRequest(newTodo)
+          }
+        }}
+      />
+      <button
+        data-testid="new-todo-add-button"
+        onClick={() => apiRequests.createTodoRequest(newTodo)}
+      >
+        추가
+      </button>
+    </>
+  )
+}
+
+const TodoBody = () => {
+  const { todos, focusedTodoId, setFocusedTodoId, apiRequests } =
+    useTodoContext()
+  return (
+    <TodoListUl>
+      {todos.map(({ id, todo, isCompleted, userId }) => (
+        <Todo
+          key={`${userId}-${id}`}
+          id={id}
+          text={todo}
+          completed={isCompleted}
+          isEditable={focusedTodoId === id}
+          handleUpdate={apiRequests.updateTodoRequest}
+          handleDelete={apiRequests.deleteTodoRequest}
+          handleEditable={(id: number | null) => {
+            setFocusedTodoId(id)
+          }}
+        />
+      ))}
+    </TodoListUl>
+  )
+}
+
+const TodoListUl = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -21,3 +131,6 @@ const TodoListWrapper = styled.ul`
   list-style: none;
   overflow-y: auto;
 `
+
+TodoList.Header = TodoHeader
+TodoList.Body = TodoBody

--- a/src/hooks/useTodoState.tsx
+++ b/src/hooks/useTodoState.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   TodoType,
   createTodo,
@@ -74,6 +74,10 @@ const useTodoState = () => {
     }
     setIsLoading(false)
   }
+
+  useEffect(() => {
+    getTodoRequest()
+  }, [])
 
   return {
     todos,

--- a/src/hooks/useTodoState.tsx
+++ b/src/hooks/useTodoState.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import {
+  TodoType,
+  createTodo,
+  deleteTodo,
+  getTodo,
+  updateTodo,
+} from '../pages/api'
+
+const useTodoState = () => {
+  const [todos, setTodos] = useState<TodoType[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [isError, setIsError] = useState('')
+  const [newTodo, setNewTodo] = useState('')
+  const [focusedTodoId, setFocusedTodoId] = useState<number | null>(null)
+
+  const getTodoRequest = async () => {
+    setIsLoading(true)
+    const res = await getTodo()
+    if (res.statusCode === 200) {
+      setTodos(() => res.body as TodoType[])
+    } else {
+      setIsError(res.body as string)
+    }
+    setIsLoading(false)
+  }
+
+  const createTodoRequest = async (todo: string) => {
+    setIsLoading(true)
+    if (!todo.length) {
+      alert('Todo string is empty!')
+      setIsLoading(false)
+      return
+    }
+    const res = await createTodo(todo)
+    if (res.statusCode === 201) {
+      setTodos((prev) => [...prev].concat(res.body as TodoType[]))
+      setNewTodo('')
+    } else {
+      setIsError(res.body as string)
+    }
+    setIsLoading(false)
+  }
+
+  const updateTodoRequest = async (
+    todoId: number,
+    todo: string,
+    isCompleted: boolean
+  ) => {
+    setIsLoading(true)
+    const res = await updateTodo(todoId, todo, isCompleted)
+    if (res.statusCode === 200) {
+      const updatedTodo = res.body[0] as TodoType
+      setTodos((prev) =>
+        [...prev].map((todo) => {
+          if (todo.id === updatedTodo.id) {
+            return { ...todo, ...updatedTodo }
+          }
+          return todo
+        })
+      )
+    } else {
+      setIsError(res.body as string)
+    }
+    setIsLoading(false)
+  }
+
+  const deleteTodoRequest = async (todoId: number) => {
+    const res = await deleteTodo(todoId)
+    if (res.statusCode === 204) {
+      setTodos((prev) => [...prev].filter((todo) => todo.id !== todoId))
+    } else {
+      setIsError(res.body as string)
+    }
+    setIsLoading(false)
+  }
+
+  return {
+    todos,
+    isLoading,
+    isError,
+    newTodo,
+    setNewTodo,
+    focusedTodoId,
+    setFocusedTodoId,
+    apiRequests: {
+      getTodoRequest,
+      createTodoRequest,
+      updateTodoRequest,
+      deleteTodoRequest,
+    },
+  }
+}
+
+export default useTodoState

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,78 +1,25 @@
 import { Navigate } from 'react-router-dom'
 import { useAuthState } from '../AuthProvider'
 import styled from '@emotion/styled'
-import { useEffect, useState } from 'react'
-import { TodoType, createTodo, deleteTodo, getTodo, updateTodo } from './api'
+import { useEffect } from 'react'
 import Todo from '../components/Todo'
+import useTodoState from '../hooks/useTodoState'
 
 const TodoPage = () => {
   const { userState } = useAuthState()
-  const [todos, setTodos] = useState<TodoType[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [isError, setIsError] = useState('')
-  const [newTodo, setNewTodo] = useState('')
-  const [focusedTodoId, setFocusedTodoId] = useState<number | null>(null)
-
-  const getTodoRequest = async () => {
-    const res = await getTodo()
-    if (res.statusCode === 200) {
-      setTodos(() => res.body as TodoType[])
-    } else {
-      setIsError(res.body as string)
-    }
-    setIsLoading(false)
-  }
-
-  const createTodoRequest = async (todo: string) => {
-    if (!todo.length) {
-      alert('Todo string is empty!')
-      setIsLoading(false)
-      return
-    }
-    const res = await createTodo(todo)
-    if (res.statusCode === 201) {
-      setTodos((prev) => [...prev].concat(res.body as TodoType[]))
-      setNewTodo('')
-    } else {
-      setIsError(res.body as string)
-    }
-    setIsLoading(false)
-  }
-
-  const updateTodoRequest = async (
-    todoId: number,
-    todo: string,
-    isCompleted: boolean
-  ) => {
-    const res = await updateTodo(todoId, todo, isCompleted)
-    if (res.statusCode === 200) {
-      const updatedTodo = res.body[0] as TodoType
-      setTodos((prev) =>
-        [...prev].map((todo) => {
-          if (todo.id === updatedTodo.id) {
-            return { ...todo, ...updatedTodo }
-          }
-          return todo
-        })
-      )
-    } else {
-      setIsError(res.body as string)
-    }
-    setIsLoading(false)
-  }
-
-  const deleteTodoRequest = async (todoId: number) => {
-    const res = await deleteTodo(todoId)
-    if (res.statusCode === 204) {
-      setTodos((prev) => [...prev].filter((todo) => todo.id !== todoId))
-    } else {
-      setIsError(res.body as string)
-    }
-    setIsLoading(false)
-  }
+  const {
+    todos,
+    isLoading,
+    isError,
+    newTodo,
+    setNewTodo,
+    focusedTodoId,
+    setFocusedTodoId,
+    apiRequests,
+  } = useTodoState()
 
   useEffect(() => {
-    getTodoRequest()
+    userState.auth && apiRequests.getTodoRequest()
   }, [])
 
   if (isLoading) return <div>Loading</div>
@@ -89,13 +36,13 @@ const TodoPage = () => {
           onChange={(e) => setNewTodo(() => e.target.value)}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
-              createTodoRequest(newTodo)
+              apiRequests.createTodoRequest(newTodo)
             }
           }}
         />
         <button
           data-testid="new-todo-add-button"
-          onClick={() => createTodoRequest(newTodo)}
+          onClick={() => apiRequests.createTodoRequest(newTodo)}
         >
           추가
         </button>
@@ -108,8 +55,8 @@ const TodoPage = () => {
               text={todo}
               completed={isCompleted}
               isEditable={focusedTodoId === id}
-              handleUpdate={updateTodoRequest}
-              handleDelete={deleteTodoRequest}
+              handleUpdate={apiRequests.updateTodoRequest}
+              handleDelete={apiRequests.deleteTodoRequest}
               handleEditable={(id: number | null) => {
                 setFocusedTodoId(id)
               }}

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,69 +1,19 @@
 import { Navigate } from 'react-router-dom'
 import { useAuthState } from '../AuthProvider'
 import styled from '@emotion/styled'
-import { useEffect } from 'react'
-import Todo from '../components/Todo'
-import useTodoState from '../hooks/useTodoState'
+import TodoList from '../components/TodoList'
 
 const TodoPage = () => {
   const { userState } = useAuthState()
-  const {
-    todos,
-    isLoading,
-    isError,
-    newTodo,
-    setNewTodo,
-    focusedTodoId,
-    setFocusedTodoId,
-    apiRequests,
-  } = useTodoState()
 
-  useEffect(() => {
-    userState.auth && apiRequests.getTodoRequest()
-  }, [])
-
-  if (isLoading) return <div>Loading</div>
-  if (isError) return <div>{isError}</div>
   if (!userState.auth) return <Navigate to="/signin" />
   return (
     <Section>
       <Title>TodoPage</Title>
-      <div>
-        <input
-          data-testid="new-todo-input"
-          placeholder="새로운 할 일"
-          value={newTodo}
-          onChange={(e) => setNewTodo(() => e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              apiRequests.createTodoRequest(newTodo)
-            }
-          }}
-        />
-        <button
-          data-testid="new-todo-add-button"
-          onClick={() => apiRequests.createTodoRequest(newTodo)}
-        >
-          추가
-        </button>
-        <button type="button"></button>
-        <TodoListUl>
-          {todos.map(({ id, todo, isCompleted, userId }) => (
-            <Todo
-              key={`${userId}-${id}`}
-              id={id}
-              text={todo}
-              completed={isCompleted}
-              isEditable={focusedTodoId === id}
-              handleUpdate={apiRequests.updateTodoRequest}
-              handleDelete={apiRequests.deleteTodoRequest}
-              handleEditable={(id: number | null) => {
-                setFocusedTodoId(id)
-              }}
-            />
-          ))}
-        </TodoListUl>
-      </div>
+      <TodoList>
+        <TodoList.Header />
+        <TodoList.Body />
+      </TodoList>
     </Section>
   )
 }
@@ -82,13 +32,4 @@ const Section = styled.section`
   align-items: center;
   width: 100%;
   height: 100%;
-`
-const TodoListUl = styled.ul`
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  width: 90%;
-  height: 90%;
-  list-style: none;
-  overflow-y: auto;
 `


### PR DESCRIPTION
# Description

close #20

## Changes
- 기존에는 TodoPage에 투두 리스트의 상태를 모두 관리하고 있었습니다. 
- 이 구조는 투두리스트와 관련 없는 컴포넌트들도 전부 다시 렌더링되는 문제점이 있었습니다.
- 이에 투두리스트의 상태관련 로직을 `useTodoState` 커스텀 훅으로 분리하였습니다
- 이 과정에서 투두리스트의 상태와 연관된 UI요소들을 구분하는데 용이해졌으며, 컴파운드 패턴의 `TodoList`컴포넌트로 리팩토링하게 되었습니다.
- 그 결과, 불필요한 렌더링이 줄었으며, 상태변화로직을 훅 내부에서 모아볼 수 있어 가독성이 증가하였습니다.