### PR TITLE
fix: 리디렉션 후 뒤로가기가 제대로 안 되는 

### DIFF
--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -80,7 +80,7 @@ const SignInPage = () => {
   return (
     <>
       {checkUserAuth() ? (
-        <Navigate to="/todo" />
+        <Navigate to="/todo" replace />
       ) : (
         <section>
           Sign In Page

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -83,7 +83,7 @@ const SignUpPage = () => {
   return (
     <>
       {checkUserAuth() ? (
-        <Navigate to="/todo" />
+        <Navigate to="/todo" replace />
       ) : (
         <section>
           Sign Up Page

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -6,7 +6,7 @@ import TodoList from '../components/TodoList'
 const TodoPage = () => {
   const { userState } = useAuthState()
 
-  if (!userState.auth) return <Navigate to="/signin" />
+  if (!userState.auth) return <Navigate to="/signin" replace />
   return (
     <Section>
       <Title>TodoPage</Title>


### PR DESCRIPTION
# Description

closes #30 

## Summary 
### 수정 전 문제점
- 로그인 전 `/todo`경로로 이동하면 `/signin`으로 리디렉션 됩니다.
- 로그인 성공하고 `/todo` 경로로 이동합니다.
- 그렇지만 `/todo`경로로 이동한 후, `뒤로가기`를 클릭하면 순간적으로 `/signin`으로 되돌아갔다가 `/todo`페이지로 이동합니다.
![signinpage-history-back-not-working](https://github.com/SeungrokYoon/wanted-pre-onboarding-frontend/assets/44149596/c41412a1-0c5c-4d04-801d-89df6b8afd9d)

### 원인파악
react-router-dom의 redirection은 `history.push()`로 동작합니다. 

그렇기에 히스토리 스택에 다음 경로가 쌓이게 되는데요, 

[`/`, `/signin`, `/todo`] 처럼 말이죠.

하지만 `replace`를 하게되면, `/signin`을 `/todo` 로 교체하여 [`/`, `/todo`] 와 같이 스택이 유지됩니다.


### 수정 후
- `Navigate` 옵션에 `replace=true` 를 추가했습니다.
- 이제는 `/todo`경로로 이동한 후, `뒤로가기`를 클릭하면 순간적으로 `/signin` 이전 페이지로 이동합니다.

![signinpage-working-history-back](https://github.com/SeungrokYoon/wanted-pre-onboarding-frontend/assets/44149596/0cd2fc42-2912-4b8a-932f-94d303184f5d)
